### PR TITLE
Slice 2: HRT milestones + adaptive log-view greeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Milestones should be configurable eventually, but the first version should avoid
 - [x] Add **JSON backup export/import** so users can move or restore local data — _versioned envelope (shots + optional profile); import validates against a strict schema and downloads a safety backup before replacing_
 - [ ] Add **filters** (e.g., last 30 days, only high-pain days, only thigh injections)
 - [ ] Add **simple charts** (pain over time, mood trends)
+- [ ] _Engineering:_ introduce a **branded `CivilDate` type** for `YYYY-MM-DD` values, produced only by the shared civil-date parser at each trust boundary (import, form input, storage read) and consumed by all date logic (milestones, greeting, shot-day, filters, charts). Best done alongside the date-range/chart work above, since that's when the model (`ShotEntry.date`, `Profile.startDate`) and its tests are already being touched — it makes invalid dates unrepresentable downstream (no re-validation) and retires the last of the string-typed date handling.
 - [ ] Improve UI layout and styling
 - [ ] Add a **developer data viewer** (raw JSON, export panel)
 - [ ] Strengthen accessibility (labels, keyboard navigation)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useState } from "react";
 import { ShotForm } from "./components/ShotForm";
 import { ShotList } from "./components/ShotList";
 import { Settings } from "./components/Settings";
+import { Greeting } from "./components/Greeting";
 import { useShotsContext } from "./context/ShotsContext";
 import type { ShotEntry } from "./types/shot";
 
@@ -64,6 +65,7 @@ const App: React.FC = () => {
 
       {view === "log" ? (
         <main className="app-main">
+          <Greeting />
           <ShotForm
             onAddShot={addShot}
             onUpdateShot={handleUpdateShot}

--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -1,0 +1,23 @@
+// src/components/Greeting.tsx
+import React, { useState } from "react";
+import { useProfileContext } from "../context/ProfileContext";
+import { useShotsContext } from "../context/ShotsContext";
+import { resolveGreeting } from "../utils/greeting";
+import { todayLocalISO } from "../utils/datetime";
+
+/**
+ * The warm greeting at the top of the log view. Adapts to the user's milestone /
+ * first-time / returning state (see resolveGreeting). The date is snapshotted once
+ * at mount (lazy useState) so the greeting stays stable for the session and only
+ * re-derives on a reload or a profile/shots change — no clock-watching.
+ *
+ * Rendered as a paragraph, not a heading (the app title is the h1).
+ */
+export const Greeting: React.FC = () => {
+  const { profile } = useProfileContext();
+  const { shots } = useShotsContext();
+  const [today] = useState(todayLocalISO);
+  const text = resolveGreeting(profile, shots.length > 0, today);
+
+  return <p className="greeting">{text}</p>;
+};

--- a/src/components/__tests__/Greeting.test.tsx
+++ b/src/components/__tests__/Greeting.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Greeting } from "../Greeting";
+import { ShotsProvider } from "../../context/ShotsContext";
+import { ProfileProvider } from "../../context/ProfileContext";
+import { STORAGE_KEYS } from "../../storageKeys";
+import type { ShotEntry } from "../../types/shot";
+
+// Greeting reads both stores from context, so mount it under both providers.
+const renderGreeting = () =>
+  render(
+    <ShotsProvider>
+      <ProfileProvider>
+        <Greeting />
+      </ProfileProvider>
+    </ShotsProvider>
+  );
+
+const seedProfile = (p: Record<string, unknown>) =>
+  localStorage.setItem(STORAGE_KEYS.profile, JSON.stringify(p));
+const seedShots = (shots: ShotEntry[]) =>
+  localStorage.setItem(STORAGE_KEYS.shots, JSON.stringify(shots));
+
+beforeEach(() => localStorage.clear());
+afterEach(() => vi.useRealTimers());
+
+describe("Greeting", () => {
+  it("welcomes a brand-new user (no name, no shots)", () => {
+    renderGreeting();
+    expect(screen.getByText("Welcome :)")).toBeInTheDocument();
+  });
+
+  it("greets a returning user by name", () => {
+    seedProfile({ preferredName: "Lou" });
+    seedShots([{ id: "s1", date: "2026-06-01" }]);
+    renderGreeting();
+    expect(screen.getByText("Hi, Lou~")).toBeInTheDocument();
+  });
+
+  it("renders as a paragraph with the greeting class (not a heading)", () => {
+    renderGreeting();
+    const el = screen.getByText("Welcome :)");
+    expect(el.tagName).toBe("P");
+    expect(el).toHaveClass("greeting");
+  });
+
+  it("celebrates a milestone based on the mount-time date", () => {
+    // The component snapshots today at mount (useState lazy init). With the clock
+    // on the 1-year anniversary, a matching start date must surface the milestone
+    // greeting — and outrank the returning greeting even though shots exist.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-26T12:00:00")); // local noon, TZ-safe
+    seedProfile({ preferredName: "Lou", startDate: "2025-07-26" });
+    seedShots([{ id: "s1", date: "2026-06-01" }]);
+    renderGreeting();
+    expect(
+      screen.getByText("Congrats on 1 year on T, Lou!")
+    ).toBeInTheDocument();
+  });
+
+  it("renders no non-ASCII glyph (guards against emoji tofu) even for a milestone", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-26T12:00:00"));
+    seedProfile({ preferredName: "Lou", startDate: "2025-07-26" });
+    renderGreeting();
+    const el = document.querySelector(".greeting");
+    // eslint-disable-next-line no-control-regex
+    expect(el?.textContent).toMatch(/^[\x00-\x7F]*$/);
+  });
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -119,6 +119,17 @@ body {
   }
 }
 
+/* Warm greeting at the top of the log view. Spans the full width above the
+   form/list grid, gentle emphasis, one source of high-contrast text. */
+.greeting {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text);
+  text-wrap: balance;
+}
+
 .app-footer {
   margin-top: 2.5rem;
   text-align: center;

--- a/src/utils/__tests__/civilDate.test.ts
+++ b/src/utils/__tests__/civilDate.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { isRealDate, civilDateParts } from "../civilDate";
+
+describe("isRealDate", () => {
+  it("accepts real calendar dates", () => {
+    expect(isRealDate("2026-07-14")).toBe(true);
+    expect(isRealDate("2024-02-29")).toBe(true); // leap day
+  });
+
+  it("rejects malformed shapes", () => {
+    expect(isRealDate("2026-7-4")).toBe(false);
+    expect(isRealDate("07/14/2026")).toBe(false);
+    expect(isRealDate("")).toBe(false);
+    expect(isRealDate("2026-07-14T00:00")).toBe(false);
+  });
+
+  it("rejects shape-valid but impossible dates", () => {
+    expect(isRealDate("2026-13-40")).toBe(false);
+    expect(isRealDate("2026-02-30")).toBe(false);
+    expect(isRealDate("2025-02-29")).toBe(false); // non-leap
+    expect(isRealDate("2026-00-10")).toBe(false);
+  });
+});
+
+describe("civilDateParts", () => {
+  it("parses a valid date into [y, m, d]", () => {
+    expect(civilDateParts("2026-07-14")).toEqual([2026, 7, 14]);
+  });
+
+  it("returns null for an impossible or malformed date", () => {
+    expect(civilDateParts("2026-13-40")).toBeNull();
+    expect(civilDateParts("nope")).toBeNull();
+  });
+});

--- a/src/utils/__tests__/greeting.test.ts
+++ b/src/utils/__tests__/greeting.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { resolveGreeting } from "../greeting";
+import type { Profile } from "../../types/profile";
+
+// A start date whose 1-year milestone window is active on the chosen "today".
+const START = "2025-01-15";
+const ONE_YEAR_DAY = "2026-01-15"; // exactly 12 months → "1 year"
+const ORDINARY_DAY = "2025-08-01"; // ~6.5 months in, between milestone windows
+
+const profile = (over: Partial<Profile> = {}): Profile => ({ ...over });
+
+describe("resolveGreeting — milestone (top priority)", () => {
+  it("celebrates with the name", () => {
+    expect(
+      resolveGreeting(profile({ startDate: START, preferredName: "Lou" }), true, ONE_YEAR_DAY)
+    ).toBe("Congrats on 1 year on T, Lou!");
+  });
+
+  it("celebrates without a name", () => {
+    expect(resolveGreeting(profile({ startDate: START }), true, ONE_YEAR_DAY)).toBe(
+      "Congrats on 1 year on T!"
+    );
+  });
+
+  it("outranks the first-time welcome (first-day anniversary still celebrates)", () => {
+    // Brand-new user (no shots) who set a past start date landing on a milestone.
+    expect(
+      resolveGreeting(profile({ startDate: START, preferredName: "Lou" }), false, ONE_YEAR_DAY)
+    ).toBe("Congrats on 1 year on T, Lou!");
+  });
+});
+
+describe("resolveGreeting — first-time (no shots, no active milestone)", () => {
+  it("welcomes with the name", () => {
+    expect(resolveGreeting(profile({ preferredName: "Lou" }), false, ORDINARY_DAY)).toBe(
+      "Welcome, Lou :)"
+    );
+  });
+
+  it("welcomes without a name", () => {
+    expect(resolveGreeting(profile(), false, ORDINARY_DAY)).toBe("Welcome :)");
+  });
+
+  it("still welcomes when a start date is set but no milestone is active", () => {
+    expect(resolveGreeting(profile({ startDate: START }), false, ORDINARY_DAY)).toBe(
+      "Welcome :)"
+    );
+  });
+});
+
+describe("resolveGreeting — returning (has shots, no active milestone)", () => {
+  it("greets with the name", () => {
+    expect(resolveGreeting(profile({ preferredName: "Lou" }), true, ORDINARY_DAY)).toBe(
+      "Hi, Lou~"
+    );
+  });
+
+  it("greets without a name", () => {
+    expect(resolveGreeting(profile(), true, ORDINARY_DAY)).toBe("Hi there~");
+  });
+});
+
+describe("resolveGreeting — name handling", () => {
+  it("treats a blank name as absent", () => {
+    expect(resolveGreeting(profile({ preferredName: "" }), true, ORDINARY_DAY)).toBe(
+      "Hi there~"
+    );
+  });
+
+  it("keeps a name with internal spaces", () => {
+    expect(
+      resolveGreeting(profile({ preferredName: "Lou Smith" }), true, ORDINARY_DAY)
+    ).toBe("Hi, Lou Smith~");
+  });
+
+  it("never contains a non-ASCII/emoji character in any state", () => {
+    // Guard against the missing-glyph "tofu": every permutation must be plain text.
+    const messages = [
+      resolveGreeting(profile({ startDate: START, preferredName: "Lou" }), true, ONE_YEAR_DAY),
+      resolveGreeting(profile({ startDate: START }), true, ONE_YEAR_DAY),
+      resolveGreeting(profile({ preferredName: "Lou" }), false, ORDINARY_DAY),
+      resolveGreeting(profile(), false, ORDINARY_DAY),
+      resolveGreeting(profile({ preferredName: "Lou" }), true, ORDINARY_DAY),
+      resolveGreeting(profile(), true, ORDINARY_DAY),
+    ];
+    for (const msg of messages) {
+      // eslint-disable-next-line no-control-regex
+      expect(msg).toMatch(/^[\x00-\x7F]*$/); // ASCII-only, no emoji
+    }
+  });
+});

--- a/src/utils/__tests__/milestones.test.ts
+++ b/src/utils/__tests__/milestones.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import {
+  monthsOnT,
+  addMonthsCivil,
+  daysBetweenCivil,
+  mostRecentThreshold,
+  milestoneLabel,
+  currentMilestone,
+  celebrationWindowDays,
+  YEAR_ONE_WINDOW_DAYS,
+  LATER_WINDOW_DAYS,
+} from "../milestones";
+
+describe("monthsOnT", () => {
+  it("counts whole civil months, not completing until the day-of-month is reached", () => {
+    expect(monthsOnT("2025-01-15", "2025-02-14")).toBe(0); // day not yet reached
+    expect(monthsOnT("2025-01-15", "2025-02-15")).toBe(1); // exactly one month
+    expect(monthsOnT("2025-01-15", "2025-02-16")).toBe(1);
+    expect(monthsOnT("2025-01-15", "2026-01-15")).toBe(12); // one year
+  });
+
+  it("completes a month-end start on the short month's last day (matches the clamp)", () => {
+    // Jan 31 start: Feb can't reach day 31, so 1 month lands on Feb's last day.
+    expect(monthsOnT("2024-01-31", "2024-02-28")).toBe(0); // not the last day yet
+    expect(monthsOnT("2024-01-31", "2024-02-29")).toBe(1); // leap-year last day
+    expect(monthsOnT("2025-01-31", "2025-02-28")).toBe(1); // non-leap last day
+    // And the clamped anniversary date agrees with monthsOnT.
+    expect(addMonthsCivil("2024-01-31", 1)).toBe("2024-02-29");
+  });
+
+  it("is negative for a future start date", () => {
+    expect(monthsOnT("2026-01-15", "2025-01-15")).toBeLessThan(0);
+  });
+
+  it("returns NaN for a malformed or impossible date", () => {
+    expect(monthsOnT("2025-1-5", "2025-02-15")).toBeNaN();
+    expect(monthsOnT("2025-01-15", "not-a-date")).toBeNaN();
+    // Shape-valid but impossible dates are rejected via the shared parseCivilDate.
+    expect(monthsOnT("2026-13-40", "2025-02-15")).toBeNaN();
+  });
+});
+
+describe("addMonthsCivil", () => {
+  it("adds months within and across a year", () => {
+    expect(addMonthsCivil("2025-01-15", 3)).toBe("2025-04-15");
+    expect(addMonthsCivil("2025-11-10", 3)).toBe("2026-02-10");
+    expect(addMonthsCivil("2025-01-15", 12)).toBe("2026-01-15");
+  });
+
+  it("clamps the day to the target month's length", () => {
+    expect(addMonthsCivil("2025-01-31", 1)).toBe("2025-02-28"); // Feb, non-leap
+    expect(addMonthsCivil("2024-01-31", 1)).toBe("2024-02-29"); // Feb, leap
+    expect(addMonthsCivil("2025-03-31", 1)).toBe("2025-04-30"); // Apr has 30
+  });
+
+  it("returns the input unchanged for a malformed date", () => {
+    expect(addMonthsCivil("nope", 3)).toBe("nope");
+  });
+});
+
+describe("daysBetweenCivil", () => {
+  it("counts calendar days", () => {
+    expect(daysBetweenCivil("2025-02-15", "2025-02-15")).toBe(0);
+    expect(daysBetweenCivil("2025-02-15", "2025-03-01")).toBe(14);
+    expect(daysBetweenCivil("2025-03-01", "2025-02-15")).toBe(-14);
+  });
+
+  it("is DST-proof (spring-forward week counts as 7 days)", () => {
+    // US DST began 2025-03-09; a naive local-midnight diff would be off by an hour.
+    expect(daysBetweenCivil("2025-03-08", "2025-03-15")).toBe(7);
+  });
+
+  it("returns NaN when either date is malformed", () => {
+    expect(daysBetweenCivil("bad", "2025-03-15")).toBeNaN();
+    expect(daysBetweenCivil("2025-03-08", "bad")).toBeNaN();
+  });
+});
+
+describe("mostRecentThreshold", () => {
+  it("is null under one month", () => {
+    expect(mostRecentThreshold(0)).toBeNull();
+    expect(mostRecentThreshold(0.5)).toBeNull();
+    expect(mostRecentThreshold(NaN)).toBeNull();
+  });
+
+  it("steps every month through the first year", () => {
+    expect(mostRecentThreshold(1)).toBe(1);
+    expect(mostRecentThreshold(5)).toBe(5);
+    expect(mostRecentThreshold(11)).toBe(11);
+    expect(mostRecentThreshold(12)).toBe(12);
+  });
+
+  it("steps every three months through the second year", () => {
+    expect(mostRecentThreshold(13)).toBe(12); // last was 1 year; next is 15
+    expect(mostRecentThreshold(15)).toBe(15);
+    expect(mostRecentThreshold(18)).toBe(18);
+    expect(mostRecentThreshold(23)).toBe(21);
+    expect(mostRecentThreshold(24)).toBe(24);
+  });
+
+  it("steps every six months after two years", () => {
+    expect(mostRecentThreshold(25)).toBe(24); // last was 2 years; next is 30
+    expect(mostRecentThreshold(30)).toBe(30);
+    expect(mostRecentThreshold(35)).toBe(30);
+    expect(mostRecentThreshold(36)).toBe(36);
+  });
+});
+
+describe("milestoneLabel", () => {
+  it("reads whole years as years, else months, singular at 1", () => {
+    expect(milestoneLabel(1)).toBe("1 month");
+    expect(milestoneLabel(2)).toBe("2 months");
+    expect(milestoneLabel(11)).toBe("11 months");
+    expect(milestoneLabel(12)).toBe("1 year");
+    expect(milestoneLabel(15)).toBe("15 months");
+    expect(milestoneLabel(18)).toBe("18 months");
+    expect(milestoneLabel(24)).toBe("2 years");
+    expect(milestoneLabel(36)).toBe("3 years");
+  });
+});
+
+describe("celebrationWindowDays", () => {
+  it("is short for year-one monthly milestones, full for whole-year anniversaries and later", () => {
+    expect(celebrationWindowDays(1)).toBe(YEAR_ONE_WINDOW_DAYS);
+    expect(celebrationWindowDays(11)).toBe(YEAR_ONE_WINDOW_DAYS);
+    expect(celebrationWindowDays(12)).toBe(LATER_WINDOW_DAYS); // 1 year — anniversary lingers
+    expect(celebrationWindowDays(15)).toBe(LATER_WINDOW_DAYS);
+    expect(celebrationWindowDays(24)).toBe(LATER_WINDOW_DAYS); // 2 years
+    expect(celebrationWindowDays(36)).toBe(LATER_WINDOW_DAYS); // 3 years
+  });
+});
+
+describe("currentMilestone", () => {
+  it("returns null when no start date is set", () => {
+    expect(currentMilestone(undefined, "2025-06-01")).toBeNull();
+  });
+
+  it("returns null for a future start date", () => {
+    expect(currentMilestone("2026-01-01", "2025-06-01")).toBeNull();
+  });
+
+  it("returns null for an impossible start date (shared strict parse)", () => {
+    expect(currentMilestone("2026-13-40", "2027-01-01")).toBeNull();
+  });
+
+  it("returns null before the first (1-month) milestone", () => {
+    expect(currentMilestone("2025-01-15", "2025-02-10")).toBeNull();
+  });
+
+  it("celebrates on the exact milestone date", () => {
+    expect(currentMilestone("2025-01-15", "2025-02-15")).toEqual({
+      months: 1,
+      label: "1 month",
+      date: "2025-02-15",
+    });
+  });
+
+  it("never shows a milestone before its date (not even the day before)", () => {
+    // The 2-month milestone date is 2025-03-15. The day before shows nothing (the
+    // 1-month window ended long ago and the 2-month one hasn't arrived).
+    expect(currentMilestone("2025-01-15", "2025-03-14")).toBeNull();
+    // ...and it appears exactly on the date.
+    expect(currentMilestone("2025-01-15", "2025-03-15")?.months).toBe(2);
+  });
+
+  it("keeps a year-one milestone within its 7-day window (inclusive of the last day)", () => {
+    const within = currentMilestone("2025-01-15", "2025-02-20"); // +5 days
+    expect(within?.months).toBe(1);
+    const edge = currentMilestone(
+      "2025-01-15",
+      addDays("2025-02-15", YEAR_ONE_WINDOW_DAYS) // +7
+    );
+    expect(edge?.months).toBe(1);
+  });
+
+  it("stops celebrating a year-one milestone once its 7-day window has passed", () => {
+    const past = currentMilestone(
+      "2025-01-15",
+      addDays("2025-02-15", YEAR_ONE_WINDOW_DAYS + 1) // +8
+    );
+    expect(past).toBeNull();
+  });
+
+  it("gives later milestones the full 14-day window", () => {
+    // 15-month milestone date is 2026-04-15. At +10 days it still shows (a year-one
+    // milestone would already be gone by +8), and it ends at +14.
+    expect(currentMilestone("2025-01-15", "2026-04-25")?.months).toBe(15); // +10
+    expect(
+      currentMilestone("2025-01-15", addDays("2026-04-15", LATER_WINDOW_DAYS))
+        ?.months
+    ).toBe(15); // +14
+    expect(
+      currentMilestone("2025-01-15", addDays("2026-04-15", LATER_WINDOW_DAYS + 1))
+    ).toBeNull(); // +15
+  });
+
+  it("celebrates the one-year milestone", () => {
+    expect(currentMilestone("2025-01-15", "2026-01-20")).toEqual({
+      months: 12,
+      label: "1 year",
+      date: "2026-01-15",
+    });
+  });
+
+  it("gives whole-year anniversaries the full 14-day window", () => {
+    // 1-year date is 2026-01-15. It still shows at +10 days (a year-one monthly
+    // milestone would already be gone by +8), and ends at +14.
+    expect(currentMilestone("2025-01-15", "2026-01-25")?.months).toBe(12); // +10
+    expect(
+      currentMilestone("2025-01-15", addDays("2026-01-15", LATER_WINDOW_DAYS))
+        ?.months
+    ).toBe(12); // +14
+    expect(
+      currentMilestone("2025-01-15", addDays("2026-01-15", LATER_WINDOW_DAYS + 1))
+    ).toBeNull(); // +15
+  });
+
+  it("uses three-month cadence in the second year", () => {
+    // 15 months from 2025-01-15 is 2026-04-15; within window.
+    expect(currentMilestone("2025-01-15", "2026-04-18")).toEqual({
+      months: 15,
+      label: "15 months",
+      date: "2026-04-15",
+    });
+  });
+
+  it("uses six-month cadence after two years", () => {
+    // 30 months from 2025-01-15 is 2027-07-15; within window.
+    expect(currentMilestone("2025-01-15", "2027-07-18")).toEqual({
+      months: 30,
+      label: "30 months",
+      date: "2027-07-15",
+    });
+  });
+
+  it("celebrates a month-end start on the short month's last day (no off-by-one)", () => {
+    // Jan 31 start -> 1-month milestone lands on Feb 29 (leap) and shows there.
+    expect(currentMilestone("2024-01-31", "2024-02-29")).toEqual({
+      months: 1,
+      label: "1 month",
+      date: "2024-02-29",
+    });
+    // ...and not the day before.
+    expect(currentMilestone("2024-01-31", "2024-02-28")).toBeNull();
+  });
+
+  it("surfaces only the latest milestone, and only in its window (not a stale one)", () => {
+    // ~18 days past the 1-month date and before the 2-month date: nothing shows.
+    expect(currentMilestone("2025-01-15", "2025-03-05")).toBeNull();
+  });
+});
+
+/** Test helper: add whole days to a civil date via UTC anchoring. */
+function addDays(iso: string, days: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const t = new Date(Date.UTC(y, m - 1, d + days));
+  return `${t.getUTCFullYear()}-${String(t.getUTCMonth() + 1).padStart(2, "0")}-${String(
+    t.getUTCDate()
+  ).padStart(2, "0")}`;
+}

--- a/src/utils/civilDate.ts
+++ b/src/utils/civilDate.ts
@@ -1,0 +1,42 @@
+// src/utils/civilDate.ts
+// The single source of truth for civil dates: validating and parsing plain
+// YYYY-MM-DD strings (string → bool / parts). This is deliberately separate from
+// datetime.ts, whose job is the opposite direction — deriving strings from the
+// current instant (Date → string). Keeping the two concerns in focused modules
+// (one reason to change each) also makes this the natural future home for a
+// branded `CivilDate` type: a `toCivilDate(value): CivilDate | null` constructor
+// would slot in here additively, alongside these lower-level helpers.
+
+/** Shape of a civil date string, YYYY-MM-DD. Shape only — see isRealDate for
+ *  calendar validity. Single source of truth for the pattern. */
+export const CIVIL_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Parse a *valid* civil date into [year, month(1-12), day], or null if the string
+ * isn't a real calendar date. The regex only checks shape, so we round-trip
+ * through Date to reject impossible values like 2026-13-40 or 2026-02-30. This is
+ * the one parse+validate implementation for the app — import validation, milestone
+ * math, and any future date consumer share it.
+ *
+ * Low-level parts extractor; the name `toCivilDate`/`parseCivilDate` is reserved
+ * for a future branded-type constructor (see the module header).
+ */
+export function civilDateParts(value: string): [number, number, number] | null {
+  if (!CIVIL_DATE_RE.test(value)) return null;
+  const [y, m, d] = value.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  if (
+    dt.getUTCFullYear() !== y ||
+    dt.getUTCMonth() !== m - 1 ||
+    dt.getUTCDate() !== d
+  ) {
+    return null;
+  }
+  return [y, m, d];
+}
+
+/** True for a real calendar date in YYYY-MM-DD form. Thin predicate over
+ *  civilDateParts (the single parse+validate). */
+export function isRealDate(value: string): boolean {
+  return civilDateParts(value) !== null;
+}

--- a/src/utils/greeting.ts
+++ b/src/utils/greeting.ts
@@ -1,0 +1,48 @@
+// src/utils/greeting.ts
+// Resolves the single message for the log-view greeting slot. Pure and civil-date
+// based (today passed in) so it's fully unit-testable. Priority, highest first:
+//
+//   1. milestone   — a celebration is active (see currentMilestone)
+//   2. first-time  — no shots logged yet (brand-new user)
+//   3. returning   — everyday greeting
+//
+// Every state is name-optional: the preferred name only personalises the copy, it
+// is never required. Punctuation carries the tone (celebratory "!", warm "~" / ":)")
+// deliberately no emoji: it renders as a missing-glyph box on systems without an
+// emoji font, so the copy stays plain text that renders identically everywhere.
+import type { Profile } from "../types/profile";
+import { currentMilestone } from "./milestones";
+import { todayLocalISO } from "./datetime";
+
+/**
+ * The greeting to show right now. `hasLoggedShots` distinguishes a brand-new user
+ * (welcome) from a returning one; a milestone outranks both so a first-day
+ * anniversary still gets the full celebration. `today` defaults to today's local
+ * date.
+ *
+ * The preferred name is already normalized to non-blank-or-absent at the profile
+ * boundary (useProfile's normalizeKnownFields, via isBlank, on read/write/import),
+ * so a plain falsy check suffices here and `""`/undefined fall through to the
+ * no-name copy. We deliberately do NOT re-run nonBlankString on it — that boundary
+ * owns the rule, and re-checking would be redundant double-sanitization.
+ */
+export function resolveGreeting(
+  profile: Profile,
+  hasLoggedShots: boolean,
+  today: string = todayLocalISO()
+): string {
+  const name = profile.preferredName;
+
+  const milestone = currentMilestone(profile.startDate, today);
+  if (milestone) {
+    return name
+      ? `Congrats on ${milestone.label} on T, ${name}!`
+      : `Congrats on ${milestone.label} on T!`;
+  }
+
+  if (!hasLoggedShots) {
+    return name ? `Welcome, ${name} :)` : "Welcome :)";
+  }
+
+  return name ? `Hi, ${name}~` : "Hi there~";
+}

--- a/src/utils/milestones.ts
+++ b/src/utils/milestones.ts
@@ -1,0 +1,146 @@
+// src/utils/milestones.ts
+// HRT milestone logic, driven by *time on T* (not shot count — skipped or shifted
+// shots are normal). All arithmetic is on civil dates (plain YYYY-MM-DD), never
+// `new Date("YYYY-MM-DD")` — that parses as UTC midnight and shifts the day for
+// anyone west of UTC. Parsing/validation goes through civilDate.ts.
+//
+// Cadence: every month through the first year (1..12), every three months in the
+// second year (15, 18, 21, 24), then every six months after two years (30, 36,
+// ...). A milestone is "celebratable" only on or after its date and for a short
+// window (~2 weeks) — never before it. Only the most recent milestone is surfaced.
+import { todayLocalISO } from "./datetime";
+import { civilDateParts } from "./civilDate";
+
+// How long after a milestone's date we keep celebrating it. Year-one *monthly*
+// milestones get a short window so the greeting doesn't linger most of the time;
+// whole-year anniversaries (12, 24, 36 ...) and all later milestones get the full
+// two weeks, since they're bigger, rarer landmarks.
+export const YEAR_ONE_WINDOW_DAYS = 7;
+export const LATER_WINDOW_DAYS = 14;
+
+/** True when a milestone in months lands on a whole-year anniversary (12, 24, ...). */
+function isWholeYear(months: number): boolean {
+  return months % 12 === 0;
+}
+
+/** Celebration window (days) for a milestone at `months` on T. Whole-year
+ *  anniversaries always get the full window; the other (monthly) year-one
+ *  milestones get the shorter one. */
+export function celebrationWindowDays(months: number): number {
+  if (!isWholeYear(months) && months <= 12) return YEAR_ONE_WINDOW_DAYS;
+  return LATER_WINDOW_DAYS;
+}
+
+export interface Milestone {
+  /** Months on T this milestone marks: every month in year one (1..12), then
+   *  15, 18, 21, 24 in year two, then 30, 36, ... after two years. */
+  months: number;
+  /** Human label, e.g. "1 month", "1 year", "15 months", "2 years". */
+  label: string;
+  /** Civil date (YYYY-MM-DD) the milestone was reached. */
+  date: string;
+}
+
+/** Days in a civil month (`month` is 1-based). Uses Date purely for month length,
+ *  which is timezone-independent. */
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
+/**
+ * Whole months elapsed from `start` to `today`, civil. Counts a month as complete
+ * only once the day-of-month is reached (Jan 15 → Feb 14 is 0 months, Feb 15 is 1).
+ * Negative if `start` is in the future.
+ */
+export function monthsOnT(startISO: string, todayISO: string): number {
+  const start = civilDateParts(startISO);
+  const today = civilDateParts(todayISO);
+  if (!start || !today) return NaN;
+  const [sy, sm, sd] = start;
+  const [ty, tm, td] = today;
+  let months = (ty - sy) * 12 + (tm - sm);
+  // A month completes when the start day-of-month is reached. If the start day
+  // exceeds the target month's length (e.g. a Jan-31 start in February), it
+  // completes on that month's last day instead — matching addMonthsCivil's clamp,
+  // so the two helpers agree on when a month-end milestone lands.
+  const dueDay = Math.min(sd, daysInMonth(ty, tm));
+  if (td < dueDay) months -= 1;
+  return months;
+}
+
+/** Add `months` to a civil date, clamping the day to the target month's length
+ *  (Jan 31 + 1 month → Feb 28/29). Returns YYYY-MM-DD. */
+export function addMonthsCivil(startISO: string, months: number): string {
+  const start = civilDateParts(startISO);
+  if (!start) return startISO;
+  const [y, m, d] = start;
+  const total = y * 12 + (m - 1) + months; // months since year 0, 0-based month
+  const ny = Math.floor(total / 12);
+  const nm = total - ny * 12; // 0-based month in [0, 11]
+  const nd = Math.min(d, daysInMonth(ny, nm + 1));
+  const mm = String(nm + 1).padStart(2, "0");
+  const dd = String(nd).padStart(2, "0");
+  return `${ny}-${mm}-${dd}`;
+}
+
+/** Whole days from `a` to `b`, civil (b - a). Both anchored to UTC midnight so the
+ *  count is DST-proof; they're treated purely as calendar dates. */
+export function daysBetweenCivil(aISO: string, bISO: string): number {
+  const a = civilDateParts(aISO);
+  const b = civilDateParts(bISO);
+  if (!a || !b) return NaN;
+  const aUTC = Date.UTC(a[0], a[1] - 1, a[2]);
+  const bUTC = Date.UTC(b[0], b[1] - 1, b[2]);
+  return Math.round((bUTC - aUTC) / 86_400_000);
+}
+
+/** The most recent milestone threshold reached at `months` on T, or null if none
+ *  (under one month). Every month in year one, every 3 months in year two, every
+ *  6 months after two years. */
+export function mostRecentThreshold(months: number): number | null {
+  if (!Number.isFinite(months) || months < 1) return null;
+  const m = Math.floor(months);
+  if (m <= 12) return m; // year one: every month (1..12)
+  if (m < 24) return 12 + Math.floor((m - 12) / 3) * 3; // year two: every 3 months
+  return 24 + Math.floor((m - 24) / 6) * 6; // after two years: every 6 months
+}
+
+/** Friendly label for a milestone in months: whole years read as "N year(s)",
+ *  otherwise "N month(s)" (singular at 1). */
+export function milestoneLabel(months: number): string {
+  if (isWholeYear(months)) {
+    const years = months / 12;
+    return `${years} year${years === 1 ? "" : "s"}`;
+  }
+  return `${months} month${months === 1 ? "" : "s"}`;
+}
+
+/**
+ * The milestone to celebrate right now, or null. Returns the most recent milestone
+ * reached, but only on or after its date and for up to its celebration window
+ * (see celebrationWindowDays) — never before the date (a milestone is never
+ * previewed). A start date in the future or unset, or a window that has passed,
+ * yields nothing. `todayISO` defaults to today's local date.
+ */
+export function currentMilestone(
+  startISO: string | undefined,
+  todayISO: string = todayLocalISO()
+): Milestone | null {
+  if (!startISO) return null;
+  const months = monthsOnT(startISO, todayISO);
+  const threshold = mostRecentThreshold(months);
+  if (threshold === null) return null;
+
+  const date = addMonthsCivil(startISO, threshold);
+  const daysSince = daysBetweenCivil(date, todayISO);
+  // daysSince < 0 → today is before the milestone date: never show early.
+  // daysSince > window → the celebration window has passed.
+  if (
+    !Number.isFinite(daysSince) ||
+    daysSince < 0 ||
+    daysSince > celebrationWindowDays(threshold)
+  ) {
+    return null;
+  }
+  return { months: threshold, label: milestoneLabel(threshold), date };
+}

--- a/src/utils/shotSchema.ts
+++ b/src/utils/shotSchema.ts
@@ -5,25 +5,9 @@
 import { z } from "zod";
 import { APP_NAME, FORMAT_VERSION } from "../appMeta";
 import { todayLocalISO } from "./datetime";
+import { isRealDate } from "./civilDate";
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/; // YYYY-MM-DD
 const TIME_RE = /^\d{2}:\d{2}$/; // HH:MM
-
-/**
- * True for a real calendar date in YYYY-MM-DD form. The regex only checks shape,
- * so we round-trip through Date to reject impossible values like 2026-13-40 or
- * 2026-02-30 that a hand-edited or hostile file could otherwise smuggle in.
- */
-function isRealDate(value: string): boolean {
-  if (!DATE_RE.test(value)) return false;
-  const [y, m, d] = value.split("-").map(Number);
-  const dt = new Date(Date.UTC(y, m - 1, d));
-  return (
-    dt.getUTCFullYear() === y &&
-    dt.getUTCMonth() === m - 1 &&
-    dt.getUTCDate() === d
-  );
-}
 
 /** True for a valid 24-hour HH:MM time (rejects 24:00, 08:99, etc.). */
 function isRealTime(value: string): boolean {


### PR DESCRIPTION
## What this does

Turns the profile (T start date + preferred name) from PR #22 into something the user actually *sees*: a warm, adaptive greeting at the top of the log view that celebrates HRT milestones.

- **Ordinary day:** `Hi, Lou~`
- **Brand new (no shots yet):** `Welcome, Lou :)`
- **Milestone window:** `Congrats on 1 year on T, Lou!`

The milestone message **replaces** the everyday greeting in the same slot rather than adding a separate banner — so there's nothing extra in the way and nothing to dismiss.

## How it's built (3 commits)

1. **Civil-date + milestone engine** — `civilDate.ts` (single source of truth for validating/parsing `YYYY-MM-DD`) + `milestones.ts` (`currentMilestone`). All arithmetic on civil dates, never `new Date(iso)` (UTC, drifts the day).
2. **Adaptive greeting** — pure `resolveGreeting` resolver + thin `Greeting.tsx`, wired into the log view.
3. **Roadmap doc** — notes a future branded `CivilDate` type for the date-range work.

## Key decisions

- **Cadence:** every month in year one (1–12), every 3 months in year two, every 6 months after two years.
- **Windows:** whole-year anniversaries (12, 24, 36…) and later milestones celebrate for **14 days**; monthly year-one milestones for **7**. Shown only on/after the date, **never previewed**.
- **Name-optional end to end** — the name only personalises; a milestone fires with just a start date and outranks the welcome, so a **first-day anniversary** celebrates.
- **No emoji** — 🎉 renders as a missing-glyph box without an emoji font, so copy is plain text (`!` / `:)` / `~`), guarded by an ASCII-only test.
- **No dismiss/`:ui` store, no timers, no animation** — evaluated once at mount, self-expires via the window; re-derives on reload or profile/shots change.
- **Trust-the-boundary** — the name is normalised at the profile boundary, so the resolver doesn't re-sanitise it (documented in place).

## Testing

- **282 unit tests pass**; **100% coverage** on `civilDate.ts`, `milestones.ts`, `greeting.ts`, `Greeting.tsx`. Edge cases: month-end clamping, leap years, DST-proof day math, impossible-date rejection, all greeting permutations, mount-time date behaviour.
- Verified in-browser at **320px and 390px** across every state, tofu-free, layout-safe, absent on Settings.
- Multiple `/code-review` passes; all findings resolved.

## Scope

Milestone engine + greeting only. The optional **"shot day" setting + greeting** is a deliberate separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX5aYh3dfrc9JrsMLExvHK
