### PR TITLE
Add shot-day greeting, warmer milestone labels, and future start dates

### DIFF
--- a/src/components/DataManagement.tsx
+++ b/src/components/DataManagement.tsx
@@ -177,9 +177,14 @@ export const DataManagement: React.FC<DataManagementProps> = ({
     // incomingProfile is already DTO-picked (from parseBackup), so its own keys
     // are exactly the known non-blank fields — no need to re-pick it.
     const incomingHasData = Object.keys(pending.incomingProfile).length > 0;
+    // Compare the whole picked profile, not field-by-field: pickProfileFields
+    // writes keys in a fixed order, so a serialized compare is stable AND can't
+    // silently miss a newly added field (e.g. shotDay) the way an explicit
+    // per-field check does. Any change — including a shot-day-only one — surfaces
+    // under the single generic "profile was updated" message; there is no
+    // per-field messaging.
     const profileChanged =
-      knownCurrent.startDate !== pending.incomingProfile.startDate ||
-      knownCurrent.preferredName !== pending.incomingProfile.preferredName;
+      JSON.stringify(knownCurrent) !== JSON.stringify(pending.incomingProfile);
 
     let message = `Restored ${pluralizeEntries(pending.incoming.length)} from backup.`;
     if (profileChanged) {

--- a/src/components/JourneySettings.tsx
+++ b/src/components/JourneySettings.tsx
@@ -4,10 +4,11 @@
 // removes it entirely.
 import React from "react";
 import { useProfileContext } from "../context/ProfileContext";
-import { todayLocalISO } from "../utils/datetime";
+import { WEEKDAYS, isWeekday, weekdayLabel } from "../utils/weekday";
 
 export const JourneySettings: React.FC = () => {
-  const { profile, setStartDate, setPreferredName } = useProfileContext();
+  const { profile, setStartDate, setPreferredName, setShotDay } =
+    useProfileContext();
 
   return (
     <div className="journey-settings">
@@ -16,14 +17,36 @@ export const JourneySettings: React.FC = () => {
         <input
           type="date"
           value={profile.startDate ?? ""}
-          // No future start dates — you can't have started T tomorrow.
-          max={todayLocalISO()}
+          // Future dates are allowed on purpose — you might be planning to start
+          // T later. Milestones simply don't begin until the date arrives.
           onChange={(e) => setStartDate(e.target.value || undefined)}
         />
       </label>
       <p className="field-hint">
         Used to celebrate milestones, like your first year on T. If you started
-        before installing the app, enter that date — it still counts.
+        before installing the app, enter that date — it still counts. Planning to
+        start later? A future date works too.
+      </p>
+
+      <label className="form-column">
+        Shot day
+        <select
+          value={profile.shotDay ?? ""}
+          onChange={(e) =>
+            setShotDay(isWeekday(e.target.value) ? e.target.value : undefined)
+          }
+        >
+          <option value="">No shot day</option>
+          {WEEKDAYS.map((day) => (
+            <option key={day} value={day}>
+              {weekdayLabel(day)}
+            </option>
+          ))}
+        </select>
+      </label>
+      <p className="field-hint">
+        Pick the day you usually take your shot for a little "Happy shot day!"
+        greeting. Leave it on "No shot day" to skip.
       </p>
 
       <label className="form-column">

--- a/src/components/__tests__/DataManagement.test.tsx
+++ b/src/components/__tests__/DataManagement.test.tsx
@@ -223,6 +223,29 @@ describe("DataManagement", () => {
       expect(status).not.toHaveTextContent(/profile/i);
     });
 
+    it("reports a shot-day-only change under the generic profile-updated message", async () => {
+      const onReplaceProfile = vi.fn();
+      render(
+        <DataManagement
+          shots={shots}
+          onReplaceAll={vi.fn()}
+          profile={{ shotDay: "monday" }}
+          onReplaceProfile={onReplaceProfile}
+        />
+      );
+
+      // Only the shot day differs — name and start date are both absent on each
+      // side. The change must still surface (not silently overwrite the shot day).
+      uploadText(toJson([{ id: "imp", date: "2026-05-01" }], { shotDay: "friday" }));
+      const dialog = await screen.findByRole("dialog");
+      fireEvent.click(within(dialog).getByRole("button", { name: "Replace" }));
+
+      expect(onReplaceProfile).toHaveBeenCalledWith({ shotDay: "friday" });
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Your profile was updated."
+      );
+    });
+
     it("includes the current profile in the pre-import safety backup", async () => {
       render(
         <DataManagement

--- a/src/components/__tests__/Greeting.test.tsx
+++ b/src/components/__tests__/Greeting.test.tsx
@@ -58,6 +58,16 @@ describe("Greeting", () => {
     ).toBeInTheDocument();
   });
 
+  it("celebrates the shot day based on the mount-time weekday", () => {
+    // 2026-07-26 is a Sunday; a "sunday" shot day surfaces the shot-day greeting.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-26T12:00:00"));
+    seedProfile({ preferredName: "Lou", shotDay: "sunday" });
+    seedShots([{ id: "s1", date: "2026-06-01" }]);
+    renderGreeting();
+    expect(screen.getByText("Happy shot day, Lou!")).toBeInTheDocument();
+  });
+
   it("renders no non-ASCII glyph (guards against emoji tofu) even for a milestone", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-26T12:00:00"));

--- a/src/components/__tests__/JourneySettings.test.tsx
+++ b/src/components/__tests__/JourneySettings.test.tsx
@@ -17,6 +17,8 @@ const dateInput = () =>
   screen.getByLabelText("Testosterone start date") as HTMLInputElement;
 const nameInput = () =>
   screen.getByLabelText("Preferred name") as HTMLInputElement;
+const shotDaySelect = () =>
+  screen.getByLabelText("Shot day") as HTMLSelectElement;
 const stored = () =>
   JSON.parse(localStorage.getItem(STORAGE_KEYS.profile) as string);
 
@@ -55,8 +57,29 @@ describe("JourneySettings", () => {
     expect(nameInput().value).toBe("");
   });
 
-  it("caps the start date at today (no future start dates)", () => {
+  it("allows a future start date (planning to start T later)", () => {
     renderPanel();
-    expect(dateInput().getAttribute("max")).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // No `max` cap — a future date is a legitimate, planned start.
+    expect(dateInput().getAttribute("max")).toBeNull();
+    fireEvent.change(dateInput(), { target: { value: "2099-01-01" } });
+    expect(stored()).toEqual({ startDate: "2099-01-01" });
+  });
+
+  it("defaults shot day to 'No shot day' and persists a chosen weekday", () => {
+    renderPanel();
+    expect(shotDaySelect().value).toBe("");
+    fireEvent.change(shotDaySelect(), { target: { value: "wednesday" } });
+    expect(stored()).toEqual({ shotDay: "wednesday" });
+  });
+
+  it("clearing shot day back to 'No shot day' removes it from storage", () => {
+    localStorage.setItem(
+      STORAGE_KEYS.profile,
+      JSON.stringify({ shotDay: "friday" })
+    );
+    renderPanel();
+    expect(shotDaySelect().value).toBe("friday");
+    fireEvent.change(shotDaySelect(), { target: { value: "" } });
+    expect(localStorage.getItem(STORAGE_KEYS.profile)).toBe("{}");
   });
 });

--- a/src/hooks/__tests__/useProfile.test.ts
+++ b/src/hooks/__tests__/useProfile.test.ts
@@ -50,6 +50,24 @@ describe("useProfile", () => {
     expect(result.current.profile.preferredName).toBeUndefined();
   });
 
+  it("sets, persists, and clears the shot day", () => {
+    const { result } = renderHook(() => useProfile());
+    act(() => result.current.setShotDay("wednesday"));
+    expect(result.current.profile.shotDay).toBe("wednesday");
+    expect(stored()).toEqual({ shotDay: "wednesday" });
+    act(() => result.current.setShotDay(undefined));
+    expect(result.current.profile.shotDay).toBeUndefined();
+  });
+
+  it("drops an invalid shot day from storage (enum, not free text)", () => {
+    localStorage.setItem(
+      STORAGE_KEYS.profile,
+      JSON.stringify({ shotDay: "someday", preferredName: "Lou" })
+    );
+    const { result } = renderHook(() => useProfile());
+    expect(result.current.profile).toEqual({ preferredName: "Lou" });
+  });
+
   it("coerces a corrupt (non-object) stored value to empty", () => {
     localStorage.setItem(STORAGE_KEYS.profile, JSON.stringify("nope"));
     const { result } = renderHook(() => useProfile());

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -2,8 +2,10 @@
 import { useCallback } from "react";
 import { useLocalStorage } from "./useLocalStorage";
 import type { Profile } from "../types/profile";
+import type { Weekday } from "../utils/weekday";
 import { STORAGE_KEYS } from "../storageKeys";
 import { isBlank } from "../utils/strings";
+import { isWeekday } from "../utils/weekday";
 
 export interface UseProfile {
   profile: Profile;
@@ -11,6 +13,8 @@ export interface UseProfile {
   setStartDate: (date: string | undefined) => void;
   /** Set (or clear, with undefined) the preferred name. */
   setPreferredName: (name: string | undefined) => void;
+  /** Set (or clear, with undefined) the shot-day weekday. */
+  setShotDay: (day: Weekday | undefined) => void;
   /** Merge a partial patch into the profile. */
   updateProfile: (patch: Partial<Profile>) => void;
   /** Replace the whole profile (used when restoring a backup). Passing {} clears it. */
@@ -27,6 +31,9 @@ const EMPTY: Profile = {};
 function normalizeKnownFields(o: Record<string, unknown>): void {
   if (isBlank(o.startDate)) delete o.startDate;
   if (isBlank(o.preferredName)) delete o.preferredName;
+  // shotDay is an enum, not free text: drop anything that isn't one of the seven
+  // weekday keys (a hand-edit, an old value, or "" from a cleared <select>).
+  if (!isWeekday(o.shotDay)) delete o.shotDay;
 }
 
 /**
@@ -89,10 +96,16 @@ export function useProfile(): UseProfile {
     [updateProfile]
   );
 
+  const setShotDay = useCallback(
+    (day: Weekday | undefined) => updateProfile({ shotDay: day }),
+    [updateProfile]
+  );
+
   return {
     profile,
     setStartDate,
     setPreferredName,
+    setShotDay,
     updateProfile,
     replaceProfile,
   };

--- a/src/styles.css
+++ b/src/styles.css
@@ -196,7 +196,8 @@ label {
 }
 
 input,
-textarea {
+textarea,
+select {
   border-radius: var(--radius-md);
   border: 1px solid var(--border-subtle);
   padding: 0.55rem 0.6rem;
@@ -214,7 +215,8 @@ textarea::placeholder {
 }
 
 input:focus,
-textarea:focus {
+textarea:focus,
+select:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.6);
 }

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -6,9 +6,15 @@
 // data that ShotEntry must never contain) and the T start date. It lives under
 // its own storage key and, like everything else, never leaves the device.
 // Every field is optional — the app is fully usable without setting any of it.
+import type { Weekday } from "../utils/weekday";
+
 export interface Profile {
-  /** Local calendar date HRT started (YYYY-MM-DD). May predate app install. */
+  /** Local calendar date HRT started (YYYY-MM-DD). May predate app install, and
+   *  may be in the future (someone planning to start T later). */
   startDate?: string;
   /** How the user likes to be addressed in milestone messages. Free text. */
   preferredName?: string;
+  /** Optional weekday for a celebratory "Happy shot day!" greeting. Absent means
+   *  no shot-day greeting at all — there is no guessing from logged shots. */
+  shotDay?: Weekday;
 }

--- a/src/utils/__tests__/backupDto.test.ts
+++ b/src/utils/__tests__/backupDto.test.ts
@@ -89,6 +89,15 @@ describe("pickProfileFields", () => {
       preferredName: "Lou Smith",
     });
   });
+
+  it("keeps a valid shot day and drops a bogus one", () => {
+    expect(pickProfileFields({ shotDay: "wednesday" })).toEqual({
+      shotDay: "wednesday",
+    });
+    expect(
+      pickProfileFields({ shotDay: "someday" } as unknown as Profile)
+    ).toEqual({});
+  });
 });
 
 describe("hasProfileData", () => {

--- a/src/utils/__tests__/greeting.test.ts
+++ b/src/utils/__tests__/greeting.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect } from "vitest";
 import { resolveGreeting } from "../greeting";
+import { weekdayOf } from "../weekday";
 import type { Profile } from "../../types/profile";
 
 // A start date whose 1-year milestone window is active on the chosen "today".
 const START = "2025-01-15";
 const ONE_YEAR_DAY = "2026-01-15"; // exactly 12 months → "1 year"
 const ORDINARY_DAY = "2025-08-01"; // ~6.5 months in, between milestone windows
+
+// Weekday of each fixed date, so shot-day tests match "today" without hardcoding.
+const ORDINARY_WEEKDAY = weekdayOf(ORDINARY_DAY)!;
+const ONE_YEAR_WEEKDAY = weekdayOf(ONE_YEAR_DAY)!;
+// Some weekday that is NOT the ordinary day's weekday.
+const OTHER_WEEKDAY =
+  ORDINARY_WEEKDAY === "monday" ? "tuesday" : "monday";
 
 const profile = (over: Partial<Profile> = {}): Profile => ({ ...over });
 
@@ -27,6 +35,50 @@ describe("resolveGreeting — milestone (top priority)", () => {
     expect(
       resolveGreeting(profile({ startDate: START, preferredName: "Lou" }), false, ONE_YEAR_DAY)
     ).toBe("Congrats on 1 year on T, Lou!");
+  });
+});
+
+describe("resolveGreeting — shot day", () => {
+  it("celebrates the shot day with the name", () => {
+    expect(
+      resolveGreeting(
+        profile({ shotDay: ORDINARY_WEEKDAY, preferredName: "Lou" }),
+        true,
+        ORDINARY_DAY
+      )
+    ).toBe("Happy shot day, Lou!");
+  });
+
+  it("celebrates the shot day without a name", () => {
+    expect(
+      resolveGreeting(profile({ shotDay: ORDINARY_WEEKDAY }), true, ORDINARY_DAY)
+    ).toBe("Happy shot day!");
+  });
+
+  it("says nothing shot-day-ish when today isn't the shot day", () => {
+    expect(
+      resolveGreeting(profile({ shotDay: OTHER_WEEKDAY }), true, ORDINARY_DAY)
+    ).toBe("Hi there~");
+  });
+
+  it("shows no shot-day greeting when shotDay is unset (never guessed)", () => {
+    expect(resolveGreeting(profile(), true, ORDINARY_DAY)).toBe("Hi there~");
+  });
+
+  it("is outranked by an active milestone (milestone wins the day)", () => {
+    expect(
+      resolveGreeting(
+        profile({ startDate: START, shotDay: ONE_YEAR_WEEKDAY, preferredName: "Lou" }),
+        true,
+        ONE_YEAR_DAY
+      )
+    ).toBe("Congrats on 1 year on T, Lou!");
+  });
+
+  it("outranks the first-time welcome (a set shot day beats a brand-new greeting)", () => {
+    expect(
+      resolveGreeting(profile({ shotDay: ORDINARY_WEEKDAY }), false, ORDINARY_DAY)
+    ).toBe("Happy shot day!");
   });
 });
 
@@ -82,6 +134,8 @@ describe("resolveGreeting — name handling", () => {
       resolveGreeting(profile(), false, ORDINARY_DAY),
       resolveGreeting(profile({ preferredName: "Lou" }), true, ORDINARY_DAY),
       resolveGreeting(profile(), true, ORDINARY_DAY),
+      resolveGreeting(profile({ shotDay: ORDINARY_WEEKDAY, preferredName: "Lou" }), true, ORDINARY_DAY),
+      resolveGreeting(profile({ shotDay: ORDINARY_WEEKDAY }), true, ORDINARY_DAY),
     ];
     for (const msg of messages) {
       // eslint-disable-next-line no-control-regex

--- a/src/utils/__tests__/importData.test.ts
+++ b/src/utils/__tests__/importData.test.ts
@@ -113,14 +113,31 @@ describe("parseBackup — profile", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("rejects a start date in the future (mirrors the UI's today cap)", () => {
+  it("accepts a future start date (planning to start T later)", () => {
     const result = parseBackup(
       JSON.stringify({
         ...JSON.parse(wrap([])),
         profile: { startDate: "2999-01-01" },
       })
     );
-    expect(result.ok).toBe(false);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a valid shot day and rejects a bogus one", () => {
+    const ok = parseBackup(
+      JSON.stringify({
+        ...JSON.parse(wrap([])),
+        profile: { shotDay: "wednesday" },
+      })
+    );
+    expect(ok.ok).toBe(true);
+    const bad = parseBackup(
+      JSON.stringify({
+        ...JSON.parse(wrap([])),
+        profile: { shotDay: "someday" },
+      })
+    );
+    expect(bad.ok).toBe(false);
   });
 
   it("accepts a past start date", () => {

--- a/src/utils/__tests__/milestones.test.ts
+++ b/src/utils/__tests__/milestones.test.ts
@@ -107,14 +107,15 @@ describe("mostRecentThreshold", () => {
 });
 
 describe("milestoneLabel", () => {
-  it("reads whole years as years, else months, singular at 1", () => {
+  it("expresses years + months, never months-only past a year, singular at 1", () => {
     expect(milestoneLabel(1)).toBe("1 month");
     expect(milestoneLabel(2)).toBe("2 months");
     expect(milestoneLabel(11)).toBe("11 months");
     expect(milestoneLabel(12)).toBe("1 year");
-    expect(milestoneLabel(15)).toBe("15 months");
-    expect(milestoneLabel(18)).toBe("18 months");
+    expect(milestoneLabel(15)).toBe("1 year 3 months");
+    expect(milestoneLabel(18)).toBe("1 year 6 months");
     expect(milestoneLabel(24)).toBe("2 years");
+    expect(milestoneLabel(30)).toBe("2 years 6 months");
     expect(milestoneLabel(36)).toBe("3 years");
   });
 });
@@ -219,7 +220,7 @@ describe("currentMilestone", () => {
     // 15 months from 2025-01-15 is 2026-04-15; within window.
     expect(currentMilestone("2025-01-15", "2026-04-18")).toEqual({
       months: 15,
-      label: "15 months",
+      label: "1 year 3 months",
       date: "2026-04-15",
     });
   });
@@ -228,7 +229,7 @@ describe("currentMilestone", () => {
     // 30 months from 2025-01-15 is 2027-07-15; within window.
     expect(currentMilestone("2025-01-15", "2027-07-18")).toEqual({
       months: 30,
-      label: "30 months",
+      label: "2 years 6 months",
       date: "2027-07-15",
     });
   });

--- a/src/utils/__tests__/weekday.test.ts
+++ b/src/utils/__tests__/weekday.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { WEEKDAYS, isWeekday, weekdayOf, weekdayLabel } from "../weekday";
+
+describe("WEEKDAYS", () => {
+  it("is indexed to match Date.getDay() (0 = Sunday)", () => {
+    expect(WEEKDAYS[0]).toBe("sunday");
+    expect(WEEKDAYS[6]).toBe("saturday");
+    expect(WEEKDAYS).toHaveLength(7);
+  });
+});
+
+describe("isWeekday", () => {
+  it("accepts the seven weekday keys", () => {
+    for (const day of WEEKDAYS) expect(isWeekday(day)).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(isWeekday("Monday")).toBe(false); // case-sensitive
+    expect(isWeekday("")).toBe(false);
+    expect(isWeekday("someday")).toBe(false);
+    expect(isWeekday(undefined)).toBe(false);
+    expect(isWeekday(3)).toBe(false);
+    expect(isWeekday(null)).toBe(false);
+  });
+});
+
+describe("weekdayOf", () => {
+  it("returns the civil date's weekday", () => {
+    // 2025-01-15 is a Wednesday.
+    expect(weekdayOf("2025-01-15")).toBe("wednesday");
+    // 2026-07-26 is a Sunday.
+    expect(weekdayOf("2026-07-26")).toBe("sunday");
+  });
+
+  it("is stable across a spring-forward DST boundary (uses local components)", () => {
+    // US DST began 2025-03-09 (a Sunday); the day before is Saturday.
+    expect(weekdayOf("2025-03-08")).toBe("saturday");
+    expect(weekdayOf("2025-03-09")).toBe("sunday");
+  });
+
+  it("returns null for a malformed or impossible date", () => {
+    expect(weekdayOf("2025-1-5")).toBeNull();
+    expect(weekdayOf("2026-13-40")).toBeNull();
+    expect(weekdayOf("nope")).toBeNull();
+  });
+});
+
+describe("weekdayLabel", () => {
+  it("title-cases the key", () => {
+    expect(weekdayLabel("wednesday")).toBe("Wednesday");
+    expect(weekdayLabel("sunday")).toBe("Sunday");
+  });
+});

--- a/src/utils/backupDto.ts
+++ b/src/utils/backupDto.ts
@@ -11,6 +11,7 @@
 import type { ShotEntry } from "../types/shot";
 import type { Profile } from "../types/profile";
 import { nonBlankString } from "./strings";
+import { isWeekday } from "./weekday";
 
 /** Rebuild a shot from known fields only — fresh object, no spread, no carried
  *  prototype or stray keys, no blank strings. Accepts a domain shot (export) or a
@@ -49,6 +50,7 @@ export function pickProfileFields(p: Partial<Profile>): Profile {
   if (startDate !== undefined) out.startDate = startDate;
   const preferredName = nonBlankString(p.preferredName);
   if (preferredName !== undefined) out.preferredName = preferredName;
+  if (isWeekday(p.shotDay)) out.shotDay = p.shotDay;
   return out;
 }
 

--- a/src/utils/greeting.ts
+++ b/src/utils/greeting.ts
@@ -3,8 +3,14 @@
 // based (today passed in) so it's fully unit-testable. Priority, highest first:
 //
 //   1. milestone   — a celebration is active (see currentMilestone)
-//   2. first-time  — no shots logged yet (brand-new user)
-//   3. returning   — everyday greeting
+//   2. shot day    — today is the user's chosen shot-day weekday
+//   3. first-time  — no shots logged yet (brand-new user)
+//   4. returning   — everyday greeting
+//
+// A milestone deliberately outranks shot day: it's the rarer, bigger landmark, so
+// on the rare day both land the milestone eclipses the weekly shot-day nudge. Shot
+// day is fully optional — with no shotDay set there is no shot-day greeting at all
+// (we never guess a day from logged shots).
 //
 // Every state is name-optional: the preferred name only personalises the copy, it
 // is never required. Punctuation carries the tone (celebratory "!", warm "~" / ":)")
@@ -13,6 +19,7 @@
 import type { Profile } from "../types/profile";
 import { currentMilestone } from "./milestones";
 import { todayLocalISO } from "./datetime";
+import { weekdayOf } from "./weekday";
 
 /**
  * The greeting to show right now. `hasLoggedShots` distinguishes a brand-new user
@@ -38,6 +45,10 @@ export function resolveGreeting(
     return name
       ? `Congrats on ${milestone.label} on T, ${name}!`
       : `Congrats on ${milestone.label} on T!`;
+  }
+
+  if (profile.shotDay && weekdayOf(today) === profile.shotDay) {
+    return name ? `Happy shot day, ${name}!` : "Happy shot day!";
   }
 
   if (!hasLoggedShots) {

--- a/src/utils/milestones.ts
+++ b/src/utils/milestones.ts
@@ -105,14 +105,17 @@ export function mostRecentThreshold(months: number): number | null {
   return 24 + Math.floor((m - 24) / 6) * 6; // after two years: every 6 months
 }
 
-/** Friendly label for a milestone in months: whole years read as "N year(s)",
- *  otherwise "N month(s)" (singular at 1). */
+/** Friendly label for a milestone in months, expressed as years + months so it
+ *  reads warmly rather than clinically: "1 month", "1 year", "1 year 3 months",
+ *  "2 years 6 months", "3 years". Never months-only past a year (no "15 months").
+ *  Singular/plural is kept correct on each part. */
 export function milestoneLabel(months: number): string {
-  if (isWholeYear(months)) {
-    const years = months / 12;
-    return `${years} year${years === 1 ? "" : "s"}`;
-  }
-  return `${months} month${months === 1 ? "" : "s"}`;
+  const years = Math.floor(months / 12);
+  const rem = months % 12;
+  const yearPart = years ? `${years} year${years === 1 ? "" : "s"}` : "";
+  const monthPart = rem ? `${rem} month${rem === 1 ? "" : "s"}` : "";
+  if (yearPart && monthPart) return `${yearPart} ${monthPart}`;
+  return yearPart || monthPart;
 }
 
 /**

--- a/src/utils/shotSchema.ts
+++ b/src/utils/shotSchema.ts
@@ -4,8 +4,8 @@
 // all enforced here so importData.ts can trust anything that parses.
 import { z } from "zod";
 import { APP_NAME, FORMAT_VERSION } from "../appMeta";
-import { todayLocalISO } from "./datetime";
 import { isRealDate } from "./civilDate";
+import { WEEKDAYS } from "./weekday";
 
 const TIME_RE = /^\d{2}:\d{2}$/; // HH:MM
 
@@ -45,16 +45,16 @@ export const shotEntrySchema = z.strictObject({
  * that backups are unencrypted.
  */
 export const profileSchema = z.strictObject({
-  startDate: z
-    .string()
-    .refine(isRealDate, "invalid date")
-    // Mirror the UI's `max={todayLocalISO()}` cap so a hand-edited or hostile
-    // file can't set a future start date, which milestone math would read as a
-    // negative time-on-T. Lexicographic compare is chronological for real ISO
-    // dates. Evaluated per-parse, so "today" is always current.
-    .refine((d) => d <= todayLocalISO(), "start date cannot be in the future")
-    .optional(),
+  // A future start date is allowed on purpose: someone planning to start T later
+  // is a legitimate case. The milestone engine reads a future start as "not
+  // started yet" (currentMilestone returns null until the date passes), so there
+  // is no negative-time bug to guard against — and rejecting it here would make a
+  // profile fail to re-import the very date the app let the user set.
+  startDate: z.string().refine(isRealDate, "invalid date").optional(),
   preferredName: z.string().min(1).optional(),
+  // Shot day is an enum: only the seven weekday keys are accepted, so a hand-edit
+  // or hostile file can't smuggle an arbitrary string past the boundary.
+  shotDay: z.enum(WEEKDAYS).optional(),
 });
 
 /**

--- a/src/utils/weekday.ts
+++ b/src/utils/weekday.ts
@@ -1,0 +1,44 @@
+// src/utils/weekday.ts
+// Day-of-week vocabulary for the optional "shot day" greeting. Weekdays are stored
+// as lowercase English keys (not 0-6) so a backup file reads plainly and z.enum
+// can validate them at the import boundary — see profileSchema. A weekday is not
+// PII.
+//
+// Deriving the weekday of a civil date uses a LOCAL Date constructor
+// (new Date(y, m-1, d)) so there's no UTC drift — consistent with datetime.ts,
+// where civil dates are always read from local components. `new Date("YYYY-MM-DD")`
+// would parse as UTC midnight and could report the wrong day west of UTC.
+import { civilDateParts } from "./civilDate";
+
+/** The seven weekday keys, indexed to match JS `Date.getDay()` (0 = Sunday). */
+export const WEEKDAYS = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+] as const;
+
+export type Weekday = (typeof WEEKDAYS)[number];
+
+/** True when `v` is one of the seven weekday keys. */
+export function isWeekday(v: unknown): v is Weekday {
+  return typeof v === "string" && (WEEKDAYS as readonly string[]).includes(v);
+}
+
+/** The weekday of a civil date (YYYY-MM-DD), or null if it isn't a real date.
+ *  Uses a local Date constructor purely to read the day index — timezone-safe
+ *  because the components come straight from the civil parts. */
+export function weekdayOf(iso: string): Weekday | null {
+  const parts = civilDateParts(iso);
+  if (!parts) return null;
+  const [y, m, d] = parts;
+  return WEEKDAYS[new Date(y, m - 1, d).getDay()];
+}
+
+/** Title-case label for display, e.g. "wednesday" -> "Wednesday". */
+export function weekdayLabel(day: Weekday): string {
+  return day.charAt(0).toUpperCase() + day.slice(1);
+}


### PR DESCRIPTION
## Summary

Slice 3 of the milestones / "Your journey" work — all local-only, name-optional, no new PII or network.

### Shot day
- New optional `Profile.shotDay` weekday drives a celebratory greeting: **"Happy shot day, Lou!"** (name-optional: **"Happy shot day!"**). Unset = no shot-day greeting at all — there's no guessing from logged shots.
- Greeting priority is now **milestone > shot-day > first-time > returning**. A milestone deliberately eclipses shot day on the rare day both land.
- New `src/utils/weekday.ts` owns the vocabulary: `Weekday` type derived from a `WEEKDAYS` tuple (single source of truth), `isWeekday`, and `weekdayOf` (local `Date` constructor — DST-safe, no UTC drift).
- Validated once at each trust boundary: `z.enum(WEEKDAYS)` in the import schema, `isWeekday` in the profile-store normalizer and the backup DTO allowlist.
- Settings → "Your journey" gets a **Shot day** select ("No shot day" + 7 weekdays); `select` now shares the input styling (44px tap target, matching border/focus).

### Warmer milestone labels
- `milestoneLabel` now reads **"1 year 3 months"** / **"2 years 6 months"** instead of months-only (**"15 months"**).

### Future start dates allowed
- Dropped the `JourneySettings` `max` cap and the import-schema future-date refine, fixing a **round-trip trap**: the profile store already allowed future dates, but the UI and import rejected them. Someone planning to start T later is a legitimate case; the milestone engine already reads a future start as "not started yet" (returns `null` until the date arrives).

### Import notification fix (from review)
- Restore now compares the whole picked profile **structurally** rather than field-by-field, so a shot-day-only change surfaces under the existing "profile was updated" message instead of applying silently — and the check can't drift as future profile fields are added.

## Testing
- `npm test -- --run` — **303 passing** (new/updated coverage: `weekday.ts`, greeting shot-day branch + priority + ASCII guard, label mapping, schema round-trip for future dates + `shotDay`, `useProfile` set/clear/invalid-drop, `JourneySettings` select, import shot-day-only-change message).
- `npm run build` (tsc + Vite) and `npm run lint` — clean.
- Playwright @390px: greeting rendered "Happy shot day, Lou!" on a matching weekday; Settings showed no date cap and the styled select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
