### PR TITLE
History & Charts slice A: shot data-access / selector layer

### DIFF
--- a/src/components/ShotForm.tsx
+++ b/src/components/ShotForm.tsx
@@ -98,7 +98,8 @@ export const ShotForm: React.FC<ShotFormProps> = ({
     // but a text-field fallback (older browsers) or a paste could produce an
     // impossible date. Surface it inline rather than silently accepting or
     // dropping it, and block the save.
-    if (!toCivilDate(date)) {
+    const parsedDate = toCivilDate(date);
+    if (!parsedDate) {
       setDateError("Please enter a real calendar date (YYYY-MM-DD).");
       return;
     }
@@ -106,7 +107,10 @@ export const ShotForm: React.FC<ShotFormProps> = ({
 
     const newShot: ShotEntry = {
       id: editingShot ? editingShot.id : newId(),
-      date,
+      // Store the parsed CivilDate, not the raw input, so the value written to
+      // storage is the one the boundary validated — the parser's result is the
+      // trust boundary, not just a yes/no gate.
+      date: parsedDate,
       time: time || undefined,
       doseMg: doseMg ? Number(doseMg) : undefined,
       injectionSite: injectionSite || undefined,

--- a/src/utils/__tests__/datetime.test.ts
+++ b/src/utils/__tests__/datetime.test.ts
@@ -32,6 +32,12 @@ describe("datetime helpers", () => {
     expect(localISODate(new Date("2026-01-05T12:00:00"))).toBe("2026-01-05");
   });
 
+  it("localISODate throws on an Invalid Date rather than branding NaN-NaN-NaN", () => {
+    // Branding an Invalid Date would mint a CivilDate the type system trusts as
+    // a real date — the guarantee the brand exists to uphold. Fail loud instead.
+    expect(() => localISODate(new Date("garbage"))).toThrow(RangeError);
+  });
+
   it("nowHHMM formats local wall-clock time, zero-padded", () => {
     expect(nowHHMM(new Date("2026-07-14T09:05:00"))).toBe("09:05");
     expect(nowHHMM(new Date("2026-07-14T14:40:00"))).toBe("14:40");

--- a/src/utils/__tests__/shotQuery.test.ts
+++ b/src/utils/__tests__/shotQuery.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterShots,
+  searchShotText,
+  sortShots,
+  takeRecent,
+  paginate,
+  queryShots,
+} from "../shotQuery";
+import { toCivilDate, type CivilDate } from "../civilDate";
+import type { ShotEntry } from "../../types/shot";
+
+const cd = (s: string): CivilDate => toCivilDate(s)!;
+
+let seq = 0;
+const shot = (over: Partial<ShotEntry> = {}): ShotEntry => ({
+  id: `id-${seq++}`,
+  date: "2026-07-14",
+  ...over,
+});
+
+describe("filterShots", () => {
+  it("returns every shot when the filter is empty or absent", () => {
+    const shots = [shot(), shot(), shot()];
+    expect(filterShots(shots)).toHaveLength(3);
+    expect(filterShots(shots, {})).toHaveLength(3);
+  });
+
+  it("treats a blank facet value as no constraint (like the 'Any' UI option)", () => {
+    const shots = [
+      shot({ date: "2026-07-01", injectionSite: "thigh" }),
+      shot({ date: "2026-07-20", injectionSite: "glute" }),
+    ];
+    // "" is how a filter <select>'s "Any" option is conventionally bound — it
+    // must NOT collapse the list the way a real constraint would.
+    expect(
+      filterShots(shots, {
+        dateFrom: "" as unknown as CivilDate,
+        dateTo: "" as unknown as CivilDate,
+        site: "",
+        position: "  ",
+        ester: "",
+      })
+    ).toHaveLength(2);
+  });
+
+  it("keeps shots within an inclusive date range", () => {
+    const shots = [
+      shot({ date: "2026-07-01" }),
+      shot({ date: "2026-07-15" }),
+      shot({ date: "2026-07-31" }),
+    ];
+    const out = filterShots(shots, { dateFrom: cd("2026-07-15"), dateTo: cd("2026-07-31") });
+    expect(out.map((s) => s.date)).toEqual(["2026-07-15", "2026-07-31"]);
+  });
+
+  it("applies each date bound independently", () => {
+    const shots = [shot({ date: "2026-06-30" }), shot({ date: "2026-07-15" })];
+    expect(filterShots(shots, { dateFrom: cd("2026-07-01") }).map((s) => s.date)).toEqual([
+      "2026-07-15",
+    ]);
+    expect(filterShots(shots, { dateTo: cd("2026-07-01") }).map((s) => s.date)).toEqual([
+      "2026-06-30",
+    ]);
+  });
+
+  it("matches site/position/ester case-insensitively and trims", () => {
+    const s = shot({
+      injectionSite: "Thigh",
+      injectionSitePosition: "Left",
+      testosteroneEster: "Cypionate",
+    });
+    const shots = [s, shot({ injectionSite: "glute" })];
+    expect(filterShots(shots, { site: "  thigh " })).toEqual([s]);
+    expect(filterShots(shots, { position: "LEFT" })).toEqual([s]);
+    expect(filterShots(shots, { ester: "cypionate" })).toEqual([s]);
+  });
+
+  it("excludes shots missing the facet being filtered", () => {
+    const withSite = shot({ injectionSite: "thigh" });
+    const noSite = shot({ injectionSite: undefined });
+    expect(filterShots([withSite, noSite], { site: "thigh" })).toEqual([withSite]);
+  });
+
+  it("filters an inclusive pain band and excludes shots with no pain score", () => {
+    const shots = [
+      shot({ painScore: 0 }),
+      shot({ painScore: 3 }),
+      shot({ painScore: 7 }),
+      shot({ painScore: undefined }),
+    ];
+    const out = filterShots(shots, { painMin: 3, painMax: 7 });
+    expect(out.map((s) => s.painScore)).toEqual([3, 7]);
+    // A legitimate 0 is included when the band allows it.
+    expect(filterShots(shots, { painMax: 0 }).map((s) => s.painScore)).toEqual([0]);
+  });
+
+  it("treats a NaN pain bound as no constraint (empty number input's valueAsNumber)", () => {
+    const shots = [shot({ painScore: 2 }), shot({ painScore: 8 }), shot({ painScore: undefined })];
+    // An empty <input type="number">.valueAsNumber is NaN. A NaN bound must not
+    // silently pass everything via `x < NaN` — it's "no constraint", so all shots
+    // (including the pain-less one) come through.
+    expect(filterShots(shots, { painMin: NaN })).toHaveLength(3);
+    expect(filterShots(shots, { painMax: Number("x") })).toHaveLength(3);
+  });
+
+  it("ANDs across facets", () => {
+    const match = shot({ date: "2026-07-10", injectionSite: "thigh", painScore: 2 });
+    const wrongSite = shot({ date: "2026-07-10", injectionSite: "glute", painScore: 2 });
+    const out = filterShots([match, wrongSite], {
+      dateFrom: cd("2026-07-01"),
+      site: "thigh",
+      painMax: 5,
+    });
+    expect(out).toEqual([match]);
+  });
+});
+
+describe("searchShotText", () => {
+  it("returns all shots for a blank query", () => {
+    const shots = [shot({ notes: "sore" }), shot()];
+    expect(searchShotText(shots, "")).toHaveLength(2);
+    expect(searchShotText(shots, "   ")).toHaveLength(2);
+  });
+
+  it("matches notes and mood case-insensitively as a substring", () => {
+    const inNotes = shot({ notes: "A bit Sore afterward" });
+    const inMood = shot({ mood: "Anxious" });
+    const neither = shot({ notes: "fine", mood: "good" });
+    const shots = [inNotes, inMood, neither];
+    expect(searchShotText(shots, "sore")).toEqual([inNotes]);
+    expect(searchShotText(shots, "anx")).toEqual([inMood]);
+  });
+
+  it("does not match structured fields, only free text", () => {
+    const shots = [shot({ injectionSite: "thigh", testosteroneEster: "cypionate" })];
+    expect(searchShotText(shots, "thigh")).toEqual([]);
+  });
+});
+
+describe("sortShots", () => {
+  it("defaults to newest-first", () => {
+    const a = shot({ date: "2026-07-01" });
+    const b = shot({ date: "2026-07-20" });
+    expect(sortShots([a, b]).map((s) => s.date)).toEqual(["2026-07-20", "2026-07-01"]);
+  });
+
+  it("orders oldest-first when asked", () => {
+    const a = shot({ date: "2026-07-01" });
+    const b = shot({ date: "2026-07-20" });
+    expect(sortShots([b, a], "oldest").map((s) => s.date)).toEqual([
+      "2026-07-01",
+      "2026-07-20",
+    ]);
+  });
+
+  it("does not mutate its input", () => {
+    const shots = [shot({ date: "2026-07-01" }), shot({ date: "2026-07-20" })];
+    const before = shots.map((s) => s.date);
+    sortShots(shots);
+    expect(shots.map((s) => s.date)).toEqual(before);
+  });
+});
+
+describe("takeRecent", () => {
+  it("returns the newest n shots", () => {
+    const shots = [
+      shot({ date: "2026-07-01" }),
+      shot({ date: "2026-07-10" }),
+      shot({ date: "2026-07-20" }),
+    ];
+    expect(takeRecent(shots, 2).map((s) => s.date)).toEqual(["2026-07-20", "2026-07-10"]);
+  });
+
+  it("returns [] for n <= 0 and all shots when n exceeds the count", () => {
+    const shots = [shot(), shot()];
+    expect(takeRecent(shots, 0)).toEqual([]);
+    expect(takeRecent(shots, -1)).toEqual([]);
+    expect(takeRecent(shots, 5)).toHaveLength(2);
+  });
+});
+
+describe("paginate", () => {
+  it("returns everything with hasMore false when no page is given", () => {
+    const shots = [shot(), shot(), shot()];
+    const page = paginate(shots);
+    expect(page.items).toHaveLength(3);
+    expect(page.total).toBe(3);
+    expect(page.hasMore).toBe(false);
+    // Fresh array, not the caller's reference — mutating items never touches source.
+    expect(page.items).not.toBe(shots);
+  });
+
+  it("slices a window and reports more remaining", () => {
+    const shots = [shot(), shot(), shot(), shot(), shot()];
+    const page = paginate(shots, { offset: 0, limit: 2 });
+    expect(page.items).toHaveLength(2);
+    expect(page.total).toBe(5);
+    expect(page.hasMore).toBe(true);
+  });
+
+  it("reports hasMore false on the last window", () => {
+    const shots = [shot(), shot(), shot()];
+    const page = paginate(shots, { offset: 2, limit: 2 });
+    expect(page.items).toHaveLength(1);
+    expect(page.hasMore).toBe(false);
+  });
+
+  it("clamps a negative offset and non-positive limit", () => {
+    const shots = [shot(), shot()];
+    expect(paginate(shots, { offset: -5, limit: 1 }).items).toHaveLength(1);
+    // A zero-width window makes no progress, so hasMore is false even though
+    // shots remain — reporting "more" would strand a "Load more" that advances
+    // by limit.
+    const none = paginate(shots, { offset: 0, limit: 0 });
+    expect(none.items).toEqual([]);
+    expect(none.hasMore).toBe(false);
+  });
+});
+
+describe("queryShots", () => {
+  it("returns all shots newest-first for an empty query", () => {
+    const a = shot({ date: "2026-07-01" });
+    const b = shot({ date: "2026-07-20" });
+    const page = queryShots([a, b]);
+    expect(page.items.map((s) => s.date)).toEqual(["2026-07-20", "2026-07-01"]);
+    expect(page.total).toBe(2);
+    expect(page.hasMore).toBe(false);
+  });
+
+  it("composes filter → search → sort → paginate with total before pagination", () => {
+    const shots = [
+      shot({ date: "2026-07-01", injectionSite: "thigh", notes: "sore" }),
+      shot({ date: "2026-07-10", injectionSite: "thigh", notes: "sore spot" }),
+      shot({ date: "2026-07-20", injectionSite: "glute", notes: "sore" }),
+      shot({ date: "2026-07-25", injectionSite: "thigh", notes: "fine" }),
+    ];
+    const page = queryShots(shots, {
+      filter: { site: "thigh" },
+      text: "sore",
+      sort: "oldest",
+      page: { offset: 0, limit: 1 },
+    });
+    // thigh + "sore" matches two shots; oldest-first, first page of one.
+    expect(page.items.map((s) => s.date)).toEqual(["2026-07-01"]);
+    expect(page.total).toBe(2);
+    expect(page.hasMore).toBe(true);
+  });
+});

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -12,8 +12,14 @@ import { unsafeCivilDate, type CivilDate } from "./civilDate";
 
 /** Local calendar date of `d` as YYYY-MM-DD (not UTC). Provably a real date —
  *  built from padded local components — so it's branded as a `CivilDate` without
- *  re-validating. */
+ *  re-validating. Guards against an Invalid Date (e.g. `new Date("garbage")`,
+ *  whose components are all NaN): branding "NaN-NaN-NaN" would hand the type
+ *  system a value it trusts as a real date, quietly breaking the CivilDate
+ *  invariant at this producer. */
 export function localISODate(d: Date = new Date()): CivilDate {
+  if (Number.isNaN(d.getTime())) {
+    throw new RangeError("localISODate: received an Invalid Date");
+  }
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");

--- a/src/utils/shotQuery.ts
+++ b/src/utils/shotQuery.ts
@@ -1,0 +1,206 @@
+// src/utils/shotQuery.ts
+// Slice A of the History & Charts epic: the client-side data-access / selector
+// layer. This is the app's "internal API" over the shot list — screens consume
+// these pure selectors, never a raw array or storage directly. It is NOT a
+// network backend (the no-network privacy model is untouched); it's the
+// ports/adapters seam that keeps a future opt-in encrypted sync a store swap
+// rather than a screen rewrite.
+//
+// Three distinct operations, deliberately named so each says what it reads:
+//   - filterShots    — structured, field-scoped constraints (date range, site,
+//                       position, pain band, ester). Faceted matching: a shot
+//                       either satisfies a facet or it doesn't.
+//   - searchShotText  — fuzzy free-text over the human-written fields (notes,
+//                       mood). One string, substring match, case-insensitive.
+//   - queryShots      — the composition: filter → search → sort → paginate,
+//                       returning a result envelope ({ items, total, hasMore }).
+//
+// You *filter* by fields, *search* by text, and a *query* wraps both. Each
+// function is pure (no storage, no dates-from-now) so the whole layer is unit-
+// testable; `today`-style ambient state never leaks in here.
+import type { ShotEntry } from "../types/shot";
+import type { CivilDate } from "./civilDate";
+import { normalizeValue } from "./suggestions";
+import { isBlank } from "./strings";
+import { compareShotsChrono } from "./sortShots";
+
+/** Newest-first (the History/Home default) or oldest-first (clinical log order). */
+export type SortOrder = "newest" | "oldest";
+
+/**
+ * Structured, field-scoped constraints — facets ONLY, never free text. Every
+ * field is optional; an omitted field is "no constraint on this facet". A shot
+ * must satisfy *all* present constraints (AND across facets). Free-text search
+ * deliberately does NOT live here — it's `searchShotText`, composed at the
+ * `ShotQuery` level — so there is exactly one home for text matching.
+ */
+export interface ShotFilter {
+  /** Inclusive lower date bound (YYYY-MM-DD). Compared lexically — valid for
+   *  civil dates. A `CivilDate` so callers parse untrusted input at the boundary. */
+  dateFrom?: CivilDate;
+  /** Inclusive upper date bound (YYYY-MM-DD). */
+  dateTo?: CivilDate;
+  /** Injection site, matched case-insensitively (exact, trimmed). */
+  site?: string;
+  /** Injection position, matched case-insensitively (exact, trimmed). */
+  position?: string;
+  /** Testosterone ester, matched case-insensitively (exact, trimmed). */
+  ester?: string;
+  /** Inclusive minimum pain score. A shot with no painScore never matches a pain bound. */
+  painMin?: number;
+  /** Inclusive maximum pain score. */
+  painMax?: number;
+}
+
+/**
+ * A whole request over the shot list: the structured `filter`, the free-text
+ * `text`, ordering, and a page window. All optional — an empty query returns
+ * every shot, newest-first, unpaginated.
+ */
+export interface ShotQuery {
+  filter?: ShotFilter;
+  /** Free-text search over notes + mood (see searchShotText). */
+  text?: string;
+  /** Result ordering; defaults to "newest". */
+  sort?: SortOrder;
+  /** Page window into the matched+sorted results. Omit for all matches. */
+  page?: { offset: number; limit: number };
+}
+
+/** The result envelope from `queryShots`: the page of items plus the counts a
+ *  "Load more" control needs. `total` is the match count BEFORE pagination. */
+export interface ShotPage {
+  items: ShotEntry[];
+  /** How many shots matched filter+search, before the page window was applied. */
+  total: number;
+  /** Whether shots remain past the current page window. */
+  hasMore: boolean;
+}
+
+/** True when `field` is present and equals `value` case-insensitively (trimmed).
+ *  A missing field never matches a set facet — filtering by site excludes shots
+ *  with no site, as faceted filtering should. */
+function fieldMatches(field: string | undefined, value: string): boolean {
+  return field !== undefined && normalizeValue(field) === normalizeValue(value);
+}
+
+/**
+ * Keep the shots that satisfy every present facet in `filter`. Pure predicate
+ * matching on structured fields — no text search, no sorting, no pagination.
+ * An empty (or absent) filter returns every shot.
+ *
+ * A blank facet value (undefined, "", or whitespace) means "no constraint",
+ * mirroring `searchShotText("")`. This matters because a filter UI conventionally
+ * binds its "Any" option to "" — treating "" as a real constraint would compare
+ * `shot.date > ""` (true for all) and silently return an empty list. String
+ * facets go through `isBlank`; the numeric pain bounds only skip on `undefined`
+ * (a real 0 bound is meaningful).
+ */
+export function filterShots(
+  shots: ShotEntry[],
+  filter: ShotFilter = {}
+): ShotEntry[] {
+  return shots.filter((shot) => {
+    if (!isBlank(filter.dateFrom) && shot.date < filter.dateFrom!) return false;
+    if (!isBlank(filter.dateTo) && shot.date > filter.dateTo!) return false;
+    if (!isBlank(filter.site) && !fieldMatches(shot.injectionSite, filter.site!))
+      return false;
+    if (
+      !isBlank(filter.position) &&
+      !fieldMatches(shot.injectionSitePosition, filter.position!)
+    )
+      return false;
+    if (
+      !isBlank(filter.ester) &&
+      !fieldMatches(shot.testosteroneEster, filter.ester!)
+    )
+      return false;
+    // Number.isFinite, not `!== undefined`: a filter UI binding painMin to
+    // Number(input) yields NaN on a blank/unparsable field, and `painScore < NaN`
+    // is always false — so a NaN bound would silently pass every shot rather than
+    // disable the facet. Treat a non-finite bound as "no constraint", same as a
+    // blank string facet above.
+    if (Number.isFinite(filter.painMin)) {
+      if (shot.painScore === undefined || shot.painScore < filter.painMin!)
+        return false;
+    }
+    if (Number.isFinite(filter.painMax)) {
+      if (shot.painScore === undefined || shot.painScore > filter.painMax!)
+        return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Keep the shots whose free-text fields (notes, mood) contain `text` as a
+ * case-insensitive substring. A blank or whitespace-only query is a no-op that
+ * returns every shot. This is the ONLY place free text is matched — structured
+ * facets belong to `filterShots`.
+ */
+export function searchShotText(shots: ShotEntry[], text: string): ShotEntry[] {
+  const needle = normalizeValue(text);
+  if (needle === "") return shots;
+  return shots.filter(
+    (shot) =>
+      normalizeValue(shot.notes ?? "").includes(needle) ||
+      normalizeValue(shot.mood ?? "").includes(needle)
+  );
+}
+
+/** A sorted copy of `shots` (never mutates the input). "newest" negates the
+ *  ascending chronological comparator (the codebase's standard spelling for
+ *  newest-first — see ShotList); "oldest" uses it directly. */
+export function sortShots(
+  shots: ShotEntry[],
+  order: SortOrder = "newest"
+): ShotEntry[] {
+  const sign = order === "newest" ? -1 : 1;
+  return [...shots].sort((a, b) => sign * compareShotsChrono(a, b));
+}
+
+/**
+ * The most recent `n` shots, newest-first — the Home teaser's source. `n <= 0`
+ * yields an empty list; asking for more than exist simply returns all of them.
+ */
+export function takeRecent(shots: ShotEntry[], n: number): ShotEntry[] {
+  if (n <= 0) return [];
+  return sortShots(shots, "newest").slice(0, n);
+}
+
+/**
+ * Slice a page window out of an already-ordered list, returning the envelope a
+ * "Load more" control needs. `total` is the length of `shots` (the full matched
+ * set), so callers pass the post-filter/post-search list here. A negative offset
+ * clamps to 0. A non-positive limit yields no items AND `hasMore: false` — a
+ * zero-width window makes no progress, so reporting "more remain" would strand a
+ * "Load more" that advances by `limit`.
+ */
+export function paginate(
+  shots: ShotEntry[],
+  page?: { offset: number; limit: number }
+): ShotPage {
+  const total = shots.length;
+  // Copy on the no-page path too, so every selector uniformly returns a fresh
+  // array — a consumer that sorts/splices page.items in place never mutates the
+  // caller's source list.
+  if (!page) return { items: [...shots], total, hasMore: false };
+  const offset = Math.max(0, page.offset);
+  const limit = Math.max(0, page.limit);
+  const items = shots.slice(offset, offset + limit);
+  return { items, total, hasMore: limit > 0 && offset + limit < total };
+}
+
+/**
+ * The composing selector: apply the structured `filter`, then free-text `text`,
+ * then order, then take the requested page. Screens call this one — it's the
+ * single entry point that guarantees the pipeline order (a filter narrows before
+ * search, `total` counts the full match set, pagination comes last).
+ */
+export function queryShots(shots: ShotEntry[], query: ShotQuery = {}): ShotPage {
+  const filtered = filterShots(shots, query.filter);
+  const searched =
+    query.text !== undefined ? searchShotText(filtered, query.text) : filtered;
+  const ordered = sortShots(searched, query.sort);
+  return paginate(ordered, query.page);
+}


### PR DESCRIPTION
## What

Introduces `src/utils/shotQuery.ts` — the pure, client-side **data-access / selector layer** that later History & Charts screens will consume instead of touching raw arrays or `localStorage`. This is slice A of the four-slice epic in the roadmap.

**Not a network backend.** The no-network privacy model is untouched; this is the client-side "internal API" (ports/adapters seam) that keeps a future opt-in encrypted sync a *store swap* rather than a screen rewrite.

## The API

Three deliberately-named operations so each name says what it reads — *filter by fields, search by text, query wraps both*:

- **`filterShots`** — structured, field-scoped facets (date range, site, position, ester, pain band). A blank string facet or a non-finite pain bound means "no constraint" (mirrors `searchShotText("")`), so a filter UI's "Any" → `""` binding, or an empty number input's `NaN` `valueAsNumber`, can't silently blank the list or disable a facet.
- **`searchShotText`** — free-text substring over `notes` + `mood`. The *only* home for text matching, so `ShotFilter` carries no text field.
- **`queryShots`** — composes `filter → search → sort → paginate` into a `{ items, total, hasMore }` envelope for a "Load more" control.

Plus `sortShots` (reuses `compareShotsChrono`), `takeRecent` (Home teaser), and `paginate`. Every selector returns a fresh array.

**No UI change** — screens wire up in slice B.

## Also: two CivilDate boundary hardenings (second commit)

Two latent, currently-behavior-identical holes at `CivilDate` producers, surfaced by review of this slice:

- `localISODate` now throws on an Invalid Date instead of branding `"NaN-NaN-NaN"` (which would mint a `CivilDate` the type system trusts as real).
- `ShotForm` stores the parsed `CivilDate` from `toCivilDate`, not the raw input string — making the parser structurally the trust boundary rather than just a yes/no gate.

## Testing

- 330 unit tests pass (`shotQuery` gets 23 covering empty/blank/NaN facets, inclusive date bounds, case-insensitive matching, the pain-band `0`-vs-`undefined` edge, AND-across-facets, search-vs-structured separation, fresh-array/non-mutation, pagination clamping, and the full `queryShots` pipeline).
- `npm run build` + `npm run lint` clean.
- Validated in a real browser (Playwright): imported the shipped module via Vite's ESM graph and exercised every selector (blank facets, NaN bounds, real pain band, fresh-array, full pipeline, `localISODate` throw) — all correct; and drove the `ShotForm` save path end to end, confirming it persists a well-formed date. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX5aYh3dfrc9JrsMLExvHK